### PR TITLE
Register follow, activate processors

### DIFF
--- a/org-ref-cite-activate.el
+++ b/org-ref-cite-activate.el
@@ -83,6 +83,9 @@ Argument CITATION is an org-element holding the references."
 				  (org-element-property :end context))
 				 'latex t))))))))
 
+(org-cite-register-processor 'org-ref-cite-activate
+  :activate #'org-ref-cite-activate)
+
 (provide 'org-ref-cite-activate)
 
 ;;; org-ref-cite-activate.el ends here

--- a/org-ref-cite-follow.el
+++ b/org-ref-cite-follow.el
@@ -299,6 +299,9 @@ If you follow on the style part you will be prompted for a key to act on."
 
 (add-hook 'org-ctrl-c-ctrl-c-hook 'org-ref-cite-Cc-Cc)
 
+(org-cite-register-processor 'org-ref-cite-follow
+  :follow #'org-ref-cite-follow)
+
 (provide 'org-ref-cite-follow)
 
 ;;; org-ref-cite-follow.el ends here


### PR DESCRIPTION
For convenience, register the activate and follow processors, as these are most likely to be used individually.

```elisp
(setq org-cite-follow-processor 'org-ref-cite-follow
      org-cite-activate-processor 'org-ref-cite-activate)
```

PS - am planing to follow this approach in my package too.