### PR TITLE
org-ref-cite-core.el: Correct Package-Requires metadata

### DIFF
--- a/org-ref-cite-core.el
+++ b/org-ref-cite-core.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/jkitchin/org-ref-cite
 ;; Version: 1.0
 ;; Keywords: org-mode, cite, ref, label
-;; Package-Requires: ((org-mode "9.5") (avy "0") (hydra "0") (bibtex-completion "0"))
+;; Package-Requires: ((org "9.5") (avy "0") (hydra "0") (bibtex-completion "0"))
 
 ;; This file is not currently part of GNU Emacs.
 ;;


### PR DESCRIPTION
Package-Requires should refer to "org" instead of "org-mode".
See: https://github.com/raxod502/straight.el/issues/854#issuecomment-929084774